### PR TITLE
refactor(day03): 依据最新个人所得税法，修改 Day03 练习题中个税免征额为 5000 元

### DIFF
--- a/Day01-15/Day03/code/tax.py
+++ b/Day01-15/Day03/code/tax.py
@@ -1,39 +1,39 @@
 """
 输入月收入和五险一金计算个人所得税
-说明：写这段代码时新的个人所得税计算方式还没有颁布
+说明：依据最新个人所得税法，个税免征额为 5000 元
 
-Version: 0.1
+Version: 0.2
 Author: 骆昊
-Date: 2018-02-28
+Date: 2019-05-21
 """
 
 salary = float(input('本月收入: '))
 insurance = float(input('五险一金: '))
-diff = salary - insurance - 3500
+diff = salary - insurance - 5000
 if diff <= 0:
     rate = 0
     deduction = 0
-elif diff < 1500:
+elif diff < 3000:
     rate = 0.03
     deduction = 0
-elif diff < 4500:
+elif diff < 12000:
     rate = 0.1
-    deduction = 105
-elif diff < 9000:
+    deduction = 210
+elif diff < 25000:
     rate = 0.2
-    deduction = 555
+    deduction = 1410
 elif diff < 35000:
     rate = 0.25
-    deduction = 1005
+    deduction = 2660
 elif diff < 55000:
     rate = 0.3
-    deduction = 2755
+    deduction = 4410
 elif diff < 80000:
     rate = 0.35
-    deduction = 5505
+    deduction = 7160
 else:
     rate = 0.45
-    deduction = 13505
+    deduction = 15160
 tax = abs(diff * rate - deduction)
 print('个人所得税: ￥%.2f元' % tax)
-print('实际到手收入: ￥%.2f元' % (diff + 3500 - tax))
+print('实际到手收入: ￥%.2f元' % (diff + 5000 - tax))

--- a/Day01-15/Day03/分支结构.md
+++ b/Day01-15/Day03/分支结构.md
@@ -192,39 +192,39 @@ else:
 """
 输入月收入和五险一金计算个人所得税
 
-Version: 0.1
+Version: 0.2
 Author: 骆昊
 """
 
 salary = float(input('本月收入: '))
 insurance = float(input('五险一金: '))
-diff = salary - insurance - 3500
+diff = salary - insurance - 5000
 if diff <= 0:
     rate = 0
     deduction = 0
-elif diff < 1500:
+elif diff < 3000:
     rate = 0.03
     deduction = 0
-elif diff < 4500:
+elif diff < 12000:
     rate = 0.1
-    deduction = 105
-elif diff < 9000:
+    deduction = 210
+elif diff < 25000:
     rate = 0.2
-    deduction = 555
+    deduction = 1410
 elif diff < 35000:
     rate = 0.25
-    deduction = 1005
+    deduction = 2660
 elif diff < 55000:
     rate = 0.3
-    deduction = 2755
+    deduction = 4410
 elif diff < 80000:
     rate = 0.35
-    deduction = 5505
+    deduction = 7160
 else:
     rate = 0.45
-    deduction = 13505
+    deduction = 15160
 tax = abs(diff * rate - deduction)
 print('个人所得税: ￥%.2f元' % tax)
-print('实际到手收入: ￥%.2f元' % (diff + 3500 - tax))
+print('实际到手收入: ￥%.2f元' % (diff + 5000 - tax))
 ```
 >**说明：** 上面的代码中使用了Python内置的`abs()`函数取绝对值来处理`-0`的问题。


### PR DESCRIPTION
Day03 课程“练习 5：个人所得税计算器”中个税计算方式为旧版（起征点 3500 元版本），现依据最新的个人所得税法，修改为起征点 5000 元版本。

按月 5000 起征点税率表如下：

| 级别 | 应纳税所得额(含税) | 税率(%) | 速算扣除数 |
| ---- | ---- | ---- | ---- |
| 1 | 不超过 3,000 元的部分 | 3 | 0 |
| 2 | 超过 3,000 元至 12,000 元的部分 | 10 | 210 |
| 3 | 超过 3,000元 至 12,000 元的部分 | 20 | 1410 |
| 4 | 超过 25,000 元至 35,000 元的部分 | 25 | 2660 |
| 5 | 超过 35,000 元至 55,000 元的部分 | 30 | 4410 |
| 6 | 超过 55,000 元至 80,000 元的部分 | 35 | 7160 |
| 7 | 超过 80,000 元的部分 | 45 | 15160 |










