### PR TITLE
修正 捕获组命名 语法并补充示例

### DIFF
--- a/Day01-15/Day12/字符串和正则表达式.md
+++ b/Day01-15/Day12/字符串和正则表达式.md
@@ -32,7 +32,7 @@
 | \|                 | 分支                                      | foo\|bar         | 可以匹配foo或者bar                                 |
 | (?#)               | 注释                                      |                  |                                                    |
 | (exp)              | 匹配exp并捕获到自动命名的组中             |                  |                                                    |
-| (?&nbsp;&lt;name&gt;exp) | 匹配exp并捕获到名为name的组中             |                  |                                                    |
+| (?P&lt;name&gt;exp) | 匹配exp并捕获到名为name的组中  | (?P&lt;pre&gt;1[3-8]\d)(?P&lt;loc&gt;\d{4})(?P&lt;num&gt;\d{4}) | 可以将手机号前3位、中间4位和末尾4位分别匹配到pre、loc和num组中           |
 | (?:exp)            | 匹配exp但是不捕获匹配的文本               |                  |                                                    |
 | (?=exp)            | 匹配exp前面的位置                         | \\b\\w+(?=ing)     | 可以匹配I'm dancing中的danc                        |
 | (?<=exp)           | 匹配exp后面的位置                         | (?<=\\bdanc)\\w+\\b | 可以匹配I love dancing and reading中的第一个ing    |


### PR DESCRIPTION
捕获组命名方式为(?P<name>exp)