### PR TITLE
Update 14.网络编程入门和网络应用开发.md

### DIFF
--- a/Day01-15/14.网络编程入门和网络应用开发.md
+++ b/Day01-15/14.网络编程入门和网络应用开发.md
@@ -151,6 +151,9 @@ def main():
     server = socket(family=AF_INET, type=SOCK_STREAM)
     # 2.绑定IP地址和端口(端口用于区分不同的服务)
     # 同一时间在同一个端口上只能绑定一个服务否则报错
+    # 需要注意的是，应首先在终端输入ifconfig
+    # 得到inet xxx.xxx.xxx.xxx netmask 0xff000000
+    # 查询实际分配到的IP私有地址替换下面代码中的IP地址即可
     server.bind(('192.168.1.2', 6789))
     # 3.开启监听 - 监听客户端连接到服务器
     # 参数512可以理解为连接队列的大小


### PR DESCRIPTION
源代码中没有考虑到不同电脑实际分配的IP私有地址不同的问题，运行后会报错：“OSError: [Errno 49] Can't assign requested address”；应该首先在终端输入ifconfig获取本地分配的IP私有地址，然后替换源代码中的IP地址，故添加注释加以说明，改正后程序可以正常运行。