### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/公开课/文档/年薪50W+的Python程序员如何写代码/code/Python/opencourse/requirements.txt
+++ b/公开课/文档/年薪50W+的Python程序员如何写代码/code/Python/opencourse/requirements.txt
@@ -32,6 +32,6 @@ six==1.14.0
 soupsieve==2.0
 traitlets==4.3.3
 typed-ast==1.4.1
-urllib3==1.25.9
+urllib3==1.26.5
 wcwidth==0.1.9
 wrapt==1.11.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.25.9
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.25.9 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>