### PR TITLE
fix(sec): upgrade numpy to 1.22.2

### DIFF
--- a/公开课/文档/年薪50W+的Python程序员如何写代码/code/Python/opencourse/requirements.txt
+++ b/公开课/文档/年薪50W+的Python程序员如何写代码/code/Python/opencourse/requirements.txt
@@ -15,7 +15,7 @@ line-profiler==3.0.2
 lxml==4.5.0
 mccabe==0.6.1
 memory-profiler==0.57.0
-numpy==1.18.3
+numpy==1.22.2
 pandas==1.0.3
 parso==0.7.0
 pexpect==4.8.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in numpy 1.18.3
- [CVE-2021-33430](https://www.oscs1024.com/hd/CVE-2021-33430)


### What did I do？
Upgrade numpy from 1.18.3 to 1.22.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS