### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/公开课/文档/年薪50W+的Python程序员如何写代码/code/Python/opencourse/requirements.txt
+++ b/公开课/文档/年薪50W+的Python程序员如何写代码/code/Python/opencourse/requirements.txt
@@ -2,7 +2,7 @@ appnope==0.1.0
 astroid==2.3.3
 backcall==0.1.0
 beautifulsoup4==4.9.0
-certifi==2020.4.5.1
+certifi==2022.12.07
 chardet==3.0.4
 decorator==4.4.2
 idna==2.9


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2020.4.5.1
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2020.4.5.1 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS