### PR TITLE
Update 70.Pandas的应用-1.md

### DIFF
--- a/Day66-80/70.Pandas的应用-1.md
+++ b/Day66-80/70.Pandas的应用-1.md
@@ -179,7 +179,7 @@ ser2[ser2 >= 500]
 dtype: int64
 ```
 
-####属性和方法
+#### 属性和方法
 
 Series对象的常用属性如下表所示。
 
@@ -358,7 +358,7 @@ dtype: float64
 ```Python
 # backfill或bfill表示用后一个元素的值填充空值
 # ffill或pad表示用前一个元素的值填充空值
-ser4.fillna(method='ffill')
+ser4.ffill()
 ```
 
 输出：


### PR DESCRIPTION
FutureWarning: Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.