### PR TITLE
does：day22，修正ujson用豆瓣镜像源的安装说明

### DIFF
--- a/Day21-30/22.对象的序列化和反序列化.md
+++ b/Day21-30/22.对象的序列化和反序列化.md
@@ -143,7 +143,7 @@ pip install ujson
 在默认情况下，pip会访问`https://pypi.org/simple/`来获得三方库相关的数据，但是国内访问这个网站的速度并不是十分理想，因此国内用户可以使用豆瓣网提供的镜像来替代这个默认的下载源，操作如下所示。
 
 ```Bash
-pip install ujson
+pip install -i https://pypi.org/simple/ ujson
 ```
 
 可以通过`pip search`命令根据名字查找需要的三方库，可以通过`pip list`命令来查看已经安装过的三方库。如果想更新某个三方库，可以使用`pip install -U`或`pip install --upgrade`；如果要删除某个三方库，可以使用`pip uninstall`命令。


### PR DESCRIPTION
day22.ujson包工具安装方法说明中,上下文的重复错误。修正了 pip 安装命令，指定了 ujson 的索引 URL。此命令为指定此次安装用豆瓣镜像源。